### PR TITLE
Restyle headline: drop "AI" from line 1, color "robotics"/"AI" orange

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,9 +361,9 @@
     </div>
 
     <h1 class="reveal">
-      0→1 <span class="serif">AI product</span><br>
+      0→1 product<br>
       builder for ambitious<br>
-      robotics and AI <span class="accent">companies.</span>
+      <span class="accent">robotics</span> and <span class="accent">AI</span> companies.
     </h1>
 
     <div class="hero-foot reveal">


### PR DESCRIPTION
## Summary
Restyles the homepage headline:
- Line 1: removed "AI" — now reads `0→1 product`
- Line 3: orange accent moved from `companies.` to the words `robotics` and `AI` — now reads `**robotics** and **AI** companies.`

End result reads: `0→1 product / builder for ambitious / **robotics** and **AI** companies.` with `robotics` and `AI` in the accent orange and everything else in default ink.

## Test plan
- [ ] Verify the headline reads "0→1 product builder for ambitious robotics and AI companies." on the live site
- [ ] Verify only "robotics" and "AI" are orange; "companies." is now black

https://claude.ai/code/session_01FC7CgbMscQb9ymfL5A1r56

---
_Generated by [Claude Code](https://claude.ai/code/session_01FC7CgbMscQb9ymfL5A1r56)_