### PR TITLE
Add GitHub Actions workflow to auto-deploy to Render on master push

### DIFF
--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,0 +1,20 @@
+name: Render deploy
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Render deploy
+        env:
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "$RENDER_DEPLOY_HOOK_URL" ]; then
+            echo "RENDER_DEPLOY_HOOK_URL secret is not set" >&2
+            exit 1
+          fi
+          curl -fsS -X POST "$RENDER_DEPLOY_HOOK_URL"


### PR DESCRIPTION
## Summary
Adds `.github/workflows/render-deploy.yml`, which calls the Render Deploy Hook on every push to `master` (plus a manual "Run workflow" button for ad-hoc redeploys).

This is the workaround path for auto-deploy — preferred over fixing it in the Render dashboard only if the GitHub→Render direct connection isn't reliable.

## Required setup before merging

Add this secret to the repo so the workflow has somewhere to POST:

1. GitHub → repo **Settings** → **Secrets and variables** → **Actions** → **New repository secret**
2. **Name:** `RENDER_DEPLOY_HOOK_URL`
3. **Value:** the full hook URL from your Render service (Settings → Deploy Hook). It looks like `https://api.render.com/deploy/srv-XXXXX?key=YYYYY`.

The workflow fails fast with a clear error if the secret isn't set, so a misconfiguration is visible in the Actions tab rather than silently no-op'ing.

## Test plan
- [ ] Add `RENDER_DEPLOY_HOOK_URL` secret in repo settings
- [ ] Merge this PR
- [ ] Watch GitHub Actions tab — the "Render deploy" workflow should run on the merge commit
- [ ] Watch Render's Events tab — a deploy should kick off within a few seconds
- [ ] (Optional) Use **Run workflow** in the Actions UI to confirm the manual trigger works

https://claude.ai/code/session_01FC7CgbMscQb9ymfL5A1r56

---
_Generated by [Claude Code](https://claude.ai/code/session_01FC7CgbMscQb9ymfL5A1r56)_