### PR TITLE
Headline: "and" → "&"

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,7 +363,7 @@
     <h1 class="reveal">
       0→1 product<br>
       builder for ambitious<br>
-      <span class="accent">robotics</span> and <span class="accent">AI</span> companies.
+      <span class="accent">robotics</span> &amp; <span class="accent">AI</span> companies.
     </h1>
 
     <div class="hero-foot reveal">


### PR DESCRIPTION
## Summary
Tiny copy tweak: headline reads `robotics & AI companies.` instead of `robotics and AI companies.` to match the desired typography. Uses `&amp;` so the ampersand renders correctly.

## Test plan
- [ ] Verify the headline shows "robotics & AI companies." on the live site
- [ ] Verify "robotics" and "AI" remain in orange; rest in black

https://claude.ai/code/session_01FC7CgbMscQb9ymfL5A1r56

---
_Generated by [Claude Code](https://claude.ai/code/session_01FC7CgbMscQb9ymfL5A1r56)_